### PR TITLE
fix syntax errors in the docker compose yml file

### DIFF
--- a/docker-compose.hub.yml
+++ b/docker-compose.hub.yml
@@ -45,14 +45,14 @@ services:
     redis:
         image: redis:alpine
         volumes:
-            - ./redis_backup:/data
+            - redis_backup:/data
         networks:
             - backend
     
     mongo:
         image: mongo
         volumes:
-            - ./mongodbs:/data/db
+            - mongodbs:/data/db
         networks:
             - backend
 

--- a/docker-compose.hub.yml
+++ b/docker-compose.hub.yml
@@ -45,14 +45,14 @@ services:
     redis:
         image: redis:alpine
         volumes:
-            - redis_backup:/data
+            - ./redis_backup:/data
         networks:
             - backend
     
     mongo:
         image: mongo
         volumes:
-            - mongodbs:/data/db
+            - ./mongodbs:/data/db
         networks:
             - backend
 
@@ -60,6 +60,6 @@ networks:
     backend:
     frontend:
 volumes:
-    mailconfig
-    redis_backup
-    mongodbs
+    mailconfig:
+    redis_backup:
+    mongodbs:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,14 +46,14 @@ services:
     redis:
         image: redis:alpine
         volumes:
-            - redis_backup:/data
+            - ./redis_backup:/data
         networks:
             - backend
     
     mongo:
         image: mongo
         volumes:
-            - mongodbs:/data/db
+            - ./mongodbs:/data/db
         networks:
             - backend
 
@@ -61,6 +61,6 @@ networks:
     backend:
     frontend:
 volumes:
-    mailconfig
-    redis_backup
-    mongodbs
+    mailconfig:
+    redis_backup:
+    mongodbs:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,14 +46,14 @@ services:
     redis:
         image: redis:alpine
         volumes:
-            - ./redis_backup:/data
+            - redis_backup:/data
         networks:
             - backend
     
     mongo:
         image: mongo
         volumes:
-            - ./mongodbs:/data/db
+            - mongodbs:/data/db
         networks:
             - backend
 


### PR DESCRIPTION
docker-compose up (docker v18.09.0) on mac & windows dies complaining about syntax errors in the docker compose yml file. this fixes the errors so it should work on all platforms