### PR TITLE
Fix spelling of API_TOKEN_SECRET in compose files

### DIFF
--- a/docker-compose.hub.yml
+++ b/docker-compose.hub.yml
@@ -24,7 +24,7 @@ services:
             - TLS_CERT=/etc/tls-keys/pub.pem    # you will need to provide these two variables.
             - API_USE_HTTPS=true
             - API_URL=https://mailserver1.astzweig.de:5438
-            - API_TOKEN=PLEASE_REPLACE_THIS
+            - API_TOKEN_SECRET=PLEASE_REPLACE_THIS
 
 # Uncomment the following lines, if you want a letsencrypt certificate and
 # your DNS provider is supported by the python lexicon dns tool.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,7 @@ services:
             - TLS_CERT=/etc/tls-keys/pub.pem    # you will need to provide these two variables.
             - API_USE_HTTPS=true
             - API_URL=https://mailserver1.astzweig.de:5438
-            - API_TOKEN=PLEASE_REPLACE_THIS
+            - API_TOKEN_SECRET=PLEASE_REPLACE_THIS
 
 # Uncomment the following lines, if you want a letsencrypt certificate and
 # your DNS provider is supported by the python lexicon dns tool.


### PR DESCRIPTION
This adds the correct environment variable to the compose files.